### PR TITLE
eqs: Add Maintainer Name

### DIFF
--- a/risingOS.maintainers
+++ b/risingOS.maintainers
@@ -30,3 +30,4 @@ Albinoman887
 Joaquin
 xioyo & F1a5H
 αиѕн
+davigamer987


### PR DESCRIPTION
Device codename has been added but maintainer name hasn't